### PR TITLE
Remove two extraneous characters from charspace

### DIFF
--- a/base62.go
+++ b/base62.go
@@ -15,7 +15,7 @@ type Encoding struct {
 	decodeMap [256]byte
 }
 
-const encodeStd = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-0123456789."
+const encodeStd = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
 
 // NewEncoding returns a new Encoding defined by the given alphabet,
 // which must be a 62-byte string.


### PR DESCRIPTION
Leaving 0x2e and 0x2d in the charspace makes it some nonstandard base64, which is less than satisfactory.

This is referenced in issue #3.
